### PR TITLE
Add random colors for the 9th and latter labels

### DIFF
--- a/src/module/resource.js
+++ b/src/module/resource.js
@@ -34,8 +34,8 @@ KityMinder.registerModule('Resource', function() {
                 colorMapping[resource] = nextIndex;
             }
 
-            // 资源过多，找不到可用索引颜色，统一返回白色
-            return RESOURCE_COLOR_SERIES[colorMapping[resource]] || RESOURCE_COLOR_OVERFLOW;
+            // 资源过多，找不到可用索引颜色时，返回随机颜色
+            return RESOURCE_COLOR_SERIES[colorMapping[resource]] || kity.Color.createHSL(Math.floor(Math.random() * 256), 100, 85);
         },
 
         /**


### PR DESCRIPTION
When labels are more than 8, the next labels will all be gray, here for improving display, I changed the new labels to use random color HSL(0-255, 100, 85), which will match the previous definitions. 
资源过多，找不到可用索引颜色时，返回随机颜色